### PR TITLE
#79

### DIFF
--- a/ms-xml/tl/tl_p010r_preTEI.xml
+++ b/ms-xml/tl/tl_p010r_preTEI.xml
@@ -63,7 +63,7 @@ appropriate for <m>distemper</m> and <m>oil</m>. </ab>
 
 <head><pa>Roses</pa></head>
 
-<ab>These are counterfeited either with the scrapings of
+    <ab>These are counterfeited<comment>c_003r_02</comment> either with the scrapings of
 <del><ill/></del> <m>horn used for lanterns</m>, or with scrapings of
 <m>parchment</m>, very clear, delicate &amp; dyed, employed as you
 know.</ab>

--- a/ms-xml/tl/tl_p038r_preTEI.xml
+++ b/ms-xml/tl/tl_p038r_preTEI.xml
@@ -51,7 +51,7 @@ those of <tmp>today</tmp> &amp; are of more lively colors. If it is for
 &amp; from such a place that there are no <del>pieces</del>
 <add>grains</add>, if it is possible. And having cut it in squares with
 <m>emery</m>, they cut it in bevel &amp; polish it. And in this manner,
-they counterfeit very beautiful <m>sapphires</m>. The old <m><fr>esmail
+    they counterfeit<comment>c_003r_02</comment> very beautiful <m>sapphires</m>. The old <m><fr>esmail
 d’azur</fr></m> for <m>silver</m> verging on aquamarine was very
 appropriate for counterfeiting <m>sapphires</m>, but it is scarcely
 found. One counterfeits <m>aquamarines</m> with <m>white glass</m>, but

--- a/ms-xml/tl/tl_p138v_preTEI.xml
+++ b/ms-xml/tl/tl_p138v_preTEI.xml
@@ -42,7 +42,7 @@ the leaves, especially, cast, can be <m>soldered</m>.</ab>
 
 <div>
 <id>p138v_3</id>
-<head><m>Counterfeit diamonds put in a work</m></head>
+    <head><m>Counterfeit<comment>c_003r_02</comment> diamonds put in a work</m></head>
 
 <ab>Give a light coat on the inside of the setting with <m>black wax
 </m>for <fr>esbaucher</fr>, then grease the inside, thus waxed, with


### PR DESCRIPTION
#79
* Consistency check imit*, contref*: OK
* tagged ```<comment>c_003r_02</comment>```  in tl_03r, tl_10r, tl_38r, tl_138v

Nota Bene: to prevent redundancy in paragraphs where words contref* appear multiple times, the note is added only on its first occurence.