### PR TITLE
#119

### DIFF
--- a/ms-xml/tl/tl_p117v_preTEI.xml
+++ b/ms-xml/tl/tl_p117v_preTEI.xml
@@ -55,7 +55,7 @@ together that the <m>enamel</m> would muddle together there. </ab>
 <id>p117v_3</id>
 <head>Sand that was used</head>
 
-<ab>Do not cast it. But because it is mixed with <m>alum de plume</m>,
+<ab>Do not cast it. But because it is mixed with <m><fr>alum de plume</fr></m>,
 you can use it in the mixture of other things &amp; it can serve in
 place of <m>brick</m>.</ab>
 

--- a/ms-xml/tl/tl_p120r_preTEI.xml
+++ b/ms-xml/tl/tl_p120r_preTEI.xml
@@ -24,7 +24,7 @@ Try <m>sheets of gemstone foil</m> molded in hollow for <al>lizards</al>
 
 <ab>Take <m>common sand</m> of <m>alum</m>, of <m>plaster</m> &amp;
 <m>brick</m>, according to the composition as said above. Add to it some
-more <m>alum de plume</m>. And mix in not the whole of a <ms>third
+more <m><fr>alum de plume</fr></m>. And mix in not the whole of a <ms>third
 part</ms> of <m><la>crocum ferri</la></m>. However its quantity cannot
 be harmful, for it is that which receives the <m>gold</m>, &amp; thanks
 to which it comes out very neatly. But it is good that your

--- a/ms-xml/tl/tl_p120v_preTEI.xml
+++ b/ms-xml/tl/tl_p120v_preTEI.xml
@@ -25,7 +25,7 @@ very fond of them.</ab>
 <ab>
 <margin>left-top</margin>
 <m><la>Crocum ferri</la></m> hardens <tl>molds</tl>, being reheated,
-&amp; <m>alum de plum</m>, as much as there is some, renders them softer
+&amp; <m><fr>alum de plume</fr></m>, as much as there is some, renders them softer
 &amp; <fr>doulx</fr>.</ab>
 
 </div>
@@ -52,7 +52,7 @@ latten</del> <corr>of</corr> <add>copper</add>, <del><fr>u</fr></del>
 <del>This</del> <add>All</add> of this makes a mass that does not sour
 at all. If the <del><fr>s</fr></del> <m>plaster</m> is good, one ought
 not add <m><la>crocum</la></m> for <m>silver</m>, but one puts more
-<m>alum de plume</m>.@ <add>It needs also some melted <m>common
+<m><fr>alum de plume</fr></m>.@ <add>It needs also some melted <m>common
 salt</m>, &amp; some <m>saltpeter</m> with the aforementioned drugs:
 <m>arsenic</m>, <m>tartar</m>, <m><la>aes ustum</la></m>, <m>copper
 filings</m>, <m>antimony</m> &amp;</add></del></ab>

--- a/ms-xml/tl/tl_p140v_preTEI.xml
+++ b/ms-xml/tl/tl_p140v_preTEI.xml
@@ -75,7 +75,7 @@ However, take heed to dry out your <tl>mold</tl> at length &amp; on a
 slow fire &amp; with patience, for there is no need to reheat it. But
 when your work is of <m>flowers</m> or other things that want <del>to
 be</del> their <tl>molds</tl> reheated &amp; set ablaze, mix in some
-<m>alum de plume</m> &amp; even some <m><la>crocum</la></m>. I have
+<m><fr>alum de plume</fr></m> &amp; even some <m><la>crocum</la></m>. I have
 molded in <m>plaster</m> &amp; <m>brick</m> very neatly &amp; it
 withstood several castings.</ab>
 


### PR DESCRIPTION
#119
query: alum de

in tl 120v line 28, I also corrected what looks like a typo: *alum de plum*